### PR TITLE
Rework ws2812-spi

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,10 @@ spi.open(0,0)
 #write 4 WS2812's, with the following colors: red, green, blue, yellow
 ws2812.write2812(spi, [[10,0,0], [0,10,0], [0,0,10], [10, 10, 0]])
 ```
-    
+
 # Notes #
-Note: this module tries to use numpy, if available.
-Without numpy it still works, but is *really* slow (more than a second
-to update 300 LED's on a Raspberry Pi Zero).
-So, if possible, do:
+Note: some tests (for example, wave.py) use numpy. However, for main module ws2812.py numpy is not required anymore.
+If you going to use test examples you should install numpy:
 ```
 sudo apt install python-numpy
 ```

--- a/wave.py
+++ b/wave.py
@@ -30,7 +30,7 @@ def test_pattern_sin(spi, nLED=8, intensity=20):
         test_off(spi, nLED)
 
 def test_off(spi, nLED):
-    ws2812.write2812(spi, [0,0,0]*nLED)
+    ws2812.write2812(spi, [[0, 0, 0]] * nLED)
 
 if __name__=="__main__":
     spi = spidev.SpiDev()

--- a/wave.py
+++ b/wave.py
@@ -1,42 +1,35 @@
 #!/usr/bin/python
-import spidev
-import ws2812
+"""
+'Wave' effect for WS2812B led strip
+"""
+
 import time
-import getopt
 import numpy
 from numpy import sin, pi
+import spidev
+import ws2812
 
-def test_pattern_sin(spi, nLED=8, intensity=20):
-    tStart=time.time()
-    indices=4*numpy.array(range(nLED), dtype=numpy.uint32)*numpy.pi/nLED
-    period0=2
-    period1=2.1
-    period2=2.2
+def _test_pattern_sin(_spi, num_leds=8, intensity=20):
+    start_time = time.time()
+    indices = 4 * numpy.array(range(num_leds), dtype=numpy.uint32) * numpy.pi / num_leds
+    period0 = 2
+    period1 = 2.1
+    period2 = 2.2
     try:
         while True:
-            t=tStart-time.time()
-            #t=1.1
-            f=numpy.zeros((nLED,3))
-            f[:,0]=sin(2*pi*t/period0+indices)
-            f[:,1]=sin(2*pi*t/period1+indices)
-            f[:,2]=sin(2*pi*t/period2+indices)
-            f=(intensity)*((f+1.0)/2.0)
-            fi=numpy.array(f, dtype=numpy.uint8)
-            #print fi[0]
-            #time_write2812(spi, fi)
-            ws2812.write2812(spi, fi)
+            _time = start_time - time.time()
+            f = numpy.zeros((num_leds, 3))
+            f[:, 0] = sin(2 * pi * _time / period0 + indices)
+            f[:, 1] = sin(2 * pi * _time / period1 + indices)
+            f[:, 2] = sin(2 *pi * _time / period2 + indices)
+            f = intensity * ((f + 1.0) / 2.0)
+            fi = numpy.array(f, dtype=numpy.uint8)
+            ws2812.write2812(_spi, fi)
             time.sleep(0.01)
     except KeyboardInterrupt:
-        test_off(spi, nLED)
+        ws2812.off_leds(_spi, num_leds)
 
-def test_off(spi, nLED):
-    ws2812.write2812(spi, [[0, 0, 0]] * nLED)
-
-if __name__=="__main__":
+if __name__ == "__main__":
     spi = spidev.SpiDev()
-    spi.open(0,0)
-    
-    test_pattern_sin(spi, nLED=8, intensity=255)
-    #test_fixed(spi)
-
-
+    spi.open(0, 0)
+    _test_pattern_sin(spi, num_leds=8, intensity=255)

--- a/ws2812.py
+++ b/ws2812.py
@@ -43,22 +43,36 @@ ENCODE_L = (
 
 SPI_XFER_SPEED = 2400000
 
-def write2812(_spi, data):
-    """
-    Encodes list of GBR led colors and sends it thru SPI bus
-    """
+def _prepare_tx_data(data):
     tx_data = []
     for rgb in data:
         for val in rgb:
             tx_data.append(ENCODE_H[(val >> 5) & 0x07])
             tx_data.append(ENCODE_M[(val >> 3) & 0x03])
             tx_data.append(ENCODE_L[(val >> 0) & 0x07])
+    return tx_data
 
-    _spi.xfer(tx_data, SPI_XFER_SPEED)
+def write2812(_spi, data):
+    """
+    Encodes list of GBR led colors and sends it thru SPI bus
+    """
+    _spi.xfer(_prepare_tx_data(data), SPI_XFER_SPEED)
+
+def off_leds(_spi, num_leds):
+    """
+    Helper function to switch off leds
+    """
+    data = [[0, 0, 0]] * num_leds
+    write2812(_spi, data)
 
 def __main():
     import getopt
     import sys
+    import timeit
+
+    t = timeit.timeit(stmt='_prepare_tx_data(data)',
+                      setup='from __main__ import _prepare_tx_data; data = [] * 30000')
+    print("_prepare_tx_data execution time (1M calls): %0.10f" % t)
 
     def _usage():
         pass


### PR DESCRIPTION
- Don't use numpy for ws2812 anymore. Instead, use lookup tables for encoding one byte to 3 bytes output (oversampling by a factor of 3). I've looked up the idea from @msperl, sorry for pun:)

- Clean up the code, make it closer to PEP8 standard.